### PR TITLE
Various fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from sdxf import *

--- a/sdxf.py
+++ b/sdxf.py
@@ -549,7 +549,7 @@ def ViewByWindow(name, leftBottom=(0, 0), rightTop=(1, 1), **options):
 class Drawing(_Collection):
     """Dxf drawing. Use append or any other list methods to add objects."""
     def __init__(self, insbase=(0.0, 0.0, 0.0), extmin=(0.0, 0.0),
-            extmax=(0.0, 0.0), layers=[Layer()], linetypes=[LineType()],
+            extmax=(0.0, 0.0), layers=[], linetypes=[LineType()],
             styles=[Style()], blocks=[], views=[], entities=None,
             fileName='test.dxf'):
         # TODO: replace list with None,arial

--- a/sdxf.py
+++ b/sdxf.py
@@ -163,8 +163,7 @@ ALIGNED, MIDDLE, FIT = 3, 4, 5  # if vertical alignment = 0
 BASELINE, BOTTOM, MIDDLE, TOP = 0, 1, 2, 3
 
 ####3) Classes
-#---entitities
-
+#---entities
 
 class Arc(_Entity):
     """Arc, angles in degrees."""


### PR DESCRIPTION
Kinda a grab-bag of different fixes. I can split them out if needed, but was feeling too lazy for the moment...
- Make it possible to use SDXF as an importable folder i.e straight "import SDXF" using submodules rather than copying sdxf.py elsewhere
- Remove default layer from Drawing, as it's not used elsewhere, which stops output having an unneeded PYDXF layer
- Fix a minor spelling mistake in comments
